### PR TITLE
Update LevelUtils.cs

### DIFF
--- a/RevitElementsElevation/LevelUtils.cs
+++ b/RevitElementsElevation/LevelUtils.cs
@@ -194,7 +194,7 @@ namespace RevitElementsElevation
             foreach (BuiltInParameter bip in builtInParameters)
             {
                 param = elem.get_Parameter(bip);
-                if (param != null && param.HasValue)
+                if (param != null && param.HasValue && (int)param.AsDouble() != 0)
                 {
                     double elev = param.AsDouble();
                     return elev;


### PR DESCRIPTION
Added 0 value check at line 197.

It seems that when you are using Generic Models, you actually have BuiltInParameter.INSTANCE_FREE_HOST_OFFSET_PARAM that actually has value near 0.
But what we really seek in this case is BuiltInParameter.INSTANCE_ELEVATION_PARAM but it is skipped, because we already got 0 value from previous Parameter.